### PR TITLE
コンテナ作成時に、pull.rebaseを設定するようにする

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "postCreateCommand": "sdk use java 21.0.2-ms",
+    "postCreateCommand": "git config pull.rebase false",
     // Codespaces立ち上げ時に自動で記載の拡張機能をインストールする
     // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
     "customizations": {


### PR DESCRIPTION
## やりたいこと

* 学生さんがpullする際に、 `git config pull.rebase false` のコマンドを打たなくて良いようにする
*  `sdk use java 21.0.2-ms` が動いていないため、不要なコマンドは削除する

## 動作確認

* 本ブランチにおけるCodespaceの起動
* 完了画面までの遷移ならびにデータ登録までの1取引の確認。

```
@takkii1010 ➜ /workspaces/tiscon10 (add-git-pull-setting) $ git config pull.rebase
false
```

## 補足
5月時点ではJava11が使用されるような挙動があったため、Java21を明示的に利用するように `postCreateCommand` を設定していた。  
現時点では解消されているようであるため、設定を削除。ただし、バージョン指定を明確にしていないため、今後も注意が必要である。

```
$ sdk current java 
Using java version 21.0.4-ms
```

```
 Microsoft     |     | 21.0.5       | ms      |            | 21.0.5-ms           
               | >>> | 21.0.4       | ms      | local only | 21.0.4-ms           
               |     | 17.0.13      | ms      |            | 17.0.13-ms          
               |     | 17.0.12      | ms      | local only | 17.0.12-ms          
               |     | 11.0.25      | ms      |            | 11.0.25-ms  
```

なお、 `"postCreateCommand": "sdk use java 21.0.4-ms && git config pull.rebase false",` のような記載は動作確認が取れず。


